### PR TITLE
Export nothing when using network-uri>=2.7

### DIFF
--- a/network-uri-static.cabal
+++ b/network-uri-static.cabal
@@ -1,5 +1,5 @@
 name: network-uri-static
-version: 0.1.2.0
+version: 0.1.2.1
 synopsis: A small utility to declare type-safe static URIs
 description:
   This library helps you declare type-safe static URIs by parsing URIs at compile time.
@@ -36,7 +36,8 @@ Flag defer-to-network-uri
   Default: False
 
 library
-  other-extensions: RecordWildCards,
+  other-extensions: CPP,
+                    RecordWildCards,
                     TemplateHaskell,
                     ViewPatterns
   if flag(defer-to-network-uri)

--- a/src/Network/URI/Static.hs
+++ b/src/Network/URI/Static.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE RecordWildCards, TemplateHaskell, ViewPatterns #-}
+{-# LANGUAGE CPP, RecordWildCards, TemplateHaskell, ViewPatterns #-}
+
+#if MIN_VERSION_network_uri(2,7,0)
+#else
 
 module Network.URI.Static
     (
@@ -107,3 +110,5 @@ instance Lift URI where
 
 instance Lift URIAuth where
     lift (URIAuth {..}) = [| URIAuth {..} |]
+
+#endif

--- a/src/Network/URI/Static.hs
+++ b/src/Network/URI/Static.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP, RecordWildCards, TemplateHaskell, ViewPatterns #-}
 
 #if MIN_VERSION_network_uri(2,7,0)
+module Network.URI.Static () where
 #else
 
 module Network.URI.Static


### PR DESCRIPTION
This PR extends https://github.com/snakamura/network-uri-static/pull/7 by declaring an empty module header, which is needed if ghc tries to compile the file.