### PR TITLE
Fix the version number of network-uri at which the consolidation took place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.2.1
+
+* The contents have been merged into network-uri, so the module is now
+  empty if you use network-uri. Bu you can still use this module at the
+  latest version if you are requiring the older network-uri for some reason.
+
 # 0.1.1.0
 
 * Added `relativeReference`.

--- a/network-uri-static.cabal
+++ b/network-uri-static.cabal
@@ -1,5 +1,5 @@
 name: network-uri-static
-version: 0.1.2.0
+version: 0.1.2.1
 synopsis: A small utility to declare type-safe static URIs
 description:
   This library helps you declare type-safe static URIs by parsing URIs at compile time.
@@ -36,7 +36,8 @@ Flag defer-to-network-uri
   Default: False
 
 library
-  other-extensions: RecordWildCards,
+  other-extensions: CPP,
+                    RecordWildCards,
                     TemplateHaskell,
                     ViewPatterns
   if flag(defer-to-network-uri)

--- a/src/Network/URI/Static.hs
+++ b/src/Network/URI/Static.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, RecordWildCards, TemplateHaskell, ViewPatterns #-}
 
-#if MIN_VERSION_network_uri(2,6,3)
+#if MIN_VERSION_network_uri(2,6,2)
 module Network.URI.Static () where
 #else
 

--- a/src/Network/URI/Static.hs
+++ b/src/Network/URI/Static.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE RecordWildCards, TemplateHaskell, ViewPatterns #-}
+{-# LANGUAGE CPP, RecordWildCards, TemplateHaskell, ViewPatterns #-}
+
+#if MIN_VERSION_network_uri(2,7,0)
+#else
 
 module Network.URI.Static
     (
@@ -107,3 +110,5 @@ instance Lift URI where
 
 instance Lift URIAuth where
     lift (URIAuth {..}) = [| URIAuth {..} |]
+
+#endif

--- a/src/Network/URI/Static.hs
+++ b/src/Network/URI/Static.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP, RecordWildCards, TemplateHaskell, ViewPatterns #-}
 
 #if MIN_VERSION_network_uri(2,7,0)
+module Network.URI.Static () where
 #else
 
 module Network.URI.Static

--- a/src/Network/URI/Static.hs
+++ b/src/Network/URI/Static.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, RecordWildCards, TemplateHaskell, ViewPatterns #-}
 
-#if MIN_VERSION_network_uri(2,6,3)
+#if MIN_VERSION_network_uri(2,7,0)
 module Network.URI.Static () where
 #else
 

--- a/src/Network/URI/Static.hs
+++ b/src/Network/URI/Static.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, RecordWildCards, TemplateHaskell, ViewPatterns #-}
 
-#if MIN_VERSION_network_uri(2,7,0)
+#if MIN_VERSION_network_uri(2,6,3)
 module Network.URI.Static () where
 #else
 


### PR DESCRIPTION
I screwed up the attempt to merge this into network-uri in that I released it as 2.7 even though no breaking changes had occurred, so I then scrubbed that release number and released the consolidation of the two packages at network-uri-2.6.3. This fixes the corresponding change in network-uri-static so that it correctly becomes silent if you have network-uri-2.6.3 or later.

(This pull request actually seems to include some material that was already merged into network-uri-static, so maybe I'm not creating the pull request correctly. Does it cause any merging pain on your side, @snakamura?)